### PR TITLE
fix linking in Gnu/Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,7 @@ AC_SUBST(LIBZIP_VERSION)
 AC_SUBST(LIBCURL_VERSION)
 AC_SUBST(OPENSSL_VERSION)
 
+
 # Checks for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O
@@ -42,6 +43,7 @@ PKG_CHECK_MODULES(libplist, libplist >= $LIBPLIST_VERSION)
 PKG_CHECK_MODULES(libzip, libzip >= $LIBZIP_VERSION)
 PKG_CHECK_MODULES(libcurl, libcurl >= $LIBCURL_VERSION)
 PKG_CHECK_MODULES(openssl, openssl >= $OPENSSL_VERSION)
+PKG_CHECK_MODULES(zlib, zlib)
 
 GLOBAL_CFLAGS=""
 AC_LDADD=""
@@ -50,6 +52,7 @@ case "$host_os" in
 	darwin*)
 	;;
 	linux*)
+	GLOBAL_CFLAGS+="-lpthread -lz"
 	;;
 	mingw*)
 		GLOBAL_CFLAGS+="-DWIN32 -D__LITTLE_ENDIAN__=1"


### PR DESCRIPTION
This fixes the following error:
/usr/bin/ld: idevicerestore-idevicerestore.o: undefined reference to
symbol 'gzclose'
/usr/bin/ld: /usr/lib/libz.so.1: error adding symbols: DSO missing from
command line